### PR TITLE
[Alternatives] fix comparison bug & improve API 

### DIFF
--- a/lib/python/Components/EpgList.py
+++ b/lib/python/Components/EpgList.py
@@ -344,9 +344,9 @@ class EPGList(GUIComponent):
 	def getIndexFromService(self, serviceref):
 		if serviceref is not None:
 			for x in range(len(self.list)):
-				if CompareWithAlternatives(self.list[x][0], serviceref.toString()):
+				if CompareWithAlternatives(self.list[x][0], serviceref):
 					return x
-				if CompareWithAlternatives(self.list[x][1], serviceref.toString()):
+				if CompareWithAlternatives(self.list[x][1], serviceref):
 					return x
 		return None
 
@@ -811,7 +811,7 @@ class EPGList(GUIComponent):
 		serviceForeColor = self.foreColorService
 		serviceBackColor = self.backColorService
 		bgpng = self.othServPix
-		if CompareWithAlternatives(service, self.currentlyPlaying and self.currentlyPlaying.toString()):
+		if CompareWithAlternatives(service, self.currentlyPlaying and self.currentlyPlaying):
 			serviceForeColor = self.foreColorServiceNow
 			serviceBackColor = self.backColorServiceNow
 			bgpng = self.nowServPix
@@ -1723,7 +1723,7 @@ class EPGBouquetList(GUIComponent):
 	def getIndexFromService(self, serviceref):
 		if serviceref is not None:
 			for x in range(len(self.bouquetslist)):
-				if CompareWithAlternatives(self.bouquetslist[x][1].toString(), serviceref.toString()):
+				if CompareWithAlternatives(self.bouquetslist[x][1], serviceref):
 					return x
 		return None
 

--- a/lib/python/Tools/Alternatives.py
+++ b/lib/python/Tools/Alternatives.py
@@ -1,17 +1,48 @@
 from enigma import eServiceCenter, eServiceReference
 
+def getServiceRef(service):
+	if isinstance(service, eServiceReference):
+		return service.ref if hasattr(service, "ref") else service
+	elif isinstance(service, str):
+		return eServiceReference(service)
+	else:
+		return eServiceReference()
+
 def getAlternativeChannels(service):
-	alternativeServices = eServiceCenter.getInstance().list(eServiceReference(service))
+	alternativeServices = eServiceCenter.getInstance().list(getServiceRef(service))
 	return alternativeServices and alternativeServices.getContent("S", True)
 
+# Get alternatives in a form useful for equality comparison: in
+# eServiceReference.toCompareString() form
+
+def getAlternativeChannelsCompare(service):
+	alternativeServices = eServiceCenter.getInstance().list(getServiceRef(service))
+	return alternativeServices and alternativeServices.getContent("C", True)
+
+# Get alternatives in a form useful for equality comparison:
+# as eServiceReference instances
+
+def getAlternativeChannelsSRef(service):
+	alternativeServices = eServiceCenter.getInstance().list(getServiceRef(service))
+	return alternativeServices and alternativeServices.getContent("R", True)
+
+# Compare service using alternatices, ensuring the serviceref strings
+# are compared in eServiceReference.toCompareString() form
+
 def CompareWithAlternatives(serviceA, serviceB):
+	serviceA = getServiceRef(serviceA)
+	serviceB = getServiceRef(serviceB)
 	return serviceA and serviceB and (
 		serviceA == serviceB or
-		serviceA.startswith('1:134:') and serviceB in getAlternativeChannels(serviceA) or
-		serviceB.startswith('1:134:') and serviceA in getAlternativeChannels(serviceB))
+		serviceA.type == 0 and serviceA.flags == 134 and serviceB in getAlternativeChannelsSRef(serviceA) or
+		serviceB.type == 0 and serviceB.flags == 134 and serviceB in getAlternativeChannelsSRef(serviceB)
+	)
+
+# Get a service's first alternative
 
 def GetWithAlternative(service):
-	if service.startswith('1:134:'):
+	service = getServiceRef(service)
+	if service.type == 0 and service.flags == 134:
 		channels = getAlternativeChannels(service)
 		if channels:
 			return channels[0]

--- a/lib/python/Tools/Alternatives.py
+++ b/lib/python/Tools/Alternatives.py
@@ -46,4 +46,4 @@ def GetWithAlternative(service):
 		channels = getAlternativeChannels(service)
 		if channels:
 			return channels[0]
-	return service
+	return service.toString()


### PR DESCRIPTION
In getAlternativeChannelsCompare(), compare using eServiceRef equality
(eServiceRef:: operator==()) rather than eServiceRef.toString() and
string equality.

This means that the serviceref flags and name fields are ignored
in the comparison.

Add a more flexible call interface in the API, allowing
the functions to be called with eServiceReference, ServiceReference
or string serficeref arguments (previously only string arguments were
allowed).

Make use of the more flexible API to avoid eServiceRef.toString() calls
in Components.EPGList.